### PR TITLE
Freebsd portability fix

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 autoreconf --install || exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -39,8 +39,11 @@ AC_PROG_LN_S
 dnl Initialize Libtool
 LT_INIT
 
+CFLAGS="${CFLAGS} -std=c99"
+CPPFLAGS="${CPPFLAGS} -D_POSIX_C_SOURCE=200112L"
+
 dnl Check if Libtool is present
-dnl Libtool is used for building share libraries 
+dnl Libtool is used for building share libraries
 AC_PROG_LIBTOOL
 
 # Checks for libraries.
@@ -76,17 +79,17 @@ AC_ARG_ENABLE([header_prefix],
     AS_HELP_STRING([--enable-header-prefix=DIR], [set the prefix for libbds header paths]),
     [],
     [enable_header_prefix=no])
-    
+
 case $enable_header_prefix in
   no)
 	AC_SUBST([AM_HEADER_PREFIX], [""])
 	AC_SUBST([BDS_HEADER_PREFIX], ["libbds"])
 	;;
   *)
-	AC_SUBST([AM_HEADER_PREFIX], ["$enable_header_prefix"])  
+	AC_SUBST([AM_HEADER_PREFIX], ["$enable_header_prefix"])
 	AC_SUBST([BDS_HEADER_PREFIX], ["$enable_header_prefix/libbds"])
 	;;
-esac	
+esac
 
 dnl ## Make sure flags are set to something (otherwise macros may set them later).
 dnl AM_CFLAGS="${AM_CFLAGS}"
@@ -125,7 +128,7 @@ dnl ## Set default settings
 dnl if [ test "x$AM_FCFLAGS" = "x" ]; then
 dnl   AM_FCFLAGS="-I/usr/local/include -I/usr/include"
 dnl else
-dnl   AM_FCFLAGS="$AM_FCFLAGS -I/usr/local/include -I/usr/include"	
+dnl   AM_FCFLAGS="$AM_FCFLAGS -I/usr/local/include -I/usr/include"
 dnl fi
 
 dnl ## ----------------------------------------------------------------------

--- a/memutil.h
+++ b/memutil.h
@@ -53,10 +53,12 @@ __attribute__((unused)) static void *xalloc_align(size_t alignment, size_t len)
 {
         len     = alignment * ((len + alignment - 1) / alignment);
 	void *v = NULL;
-#if __linux__
+#if __APPLE__ && __MACH__
+	posix_memalign(&v, alignment, len);
+#else
   #if defined(_ISOC11_SOURCE)
         v = aligned_alloc(alignment, len);
-  #else 
+  #else
     #if( _POSIX_C_SOURCE >= 200112L)
 	posix_memalign(&v, alignment, len);
     #else
@@ -67,8 +69,6 @@ __attribute__((unused)) static void *xalloc_align(size_t alignment, size_t len)
       #endif
     #endif
   #endif
-#elif __APPLE__ && __MACH__
-	posix_memalign(&v, alignment, len);
 #endif
         assert(v);
         memset(v, 0, len);


### PR DESCRIPTION
Added compiler standard flags to the libbds build configuration

Changed macOS to use specific #ifdef'ed aligned memory allocation and all other platforms to use the standard compiler macro standard settings.

Changed autogen.sh to use env command to set interpreter path.
